### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Save Git revision
       run: git log -1 --format='%H' > packages/cosmic-swingset/lib/git-revision.txt
     - name: Build Go dependencies image
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: agoric/cosmic-swingset
         dockerfile: packages/cosmic-swingset/Dockerfile
@@ -30,7 +30,7 @@ jobs:
     - uses: actions/checkout@master
     - name: Build SDK image
       # needs agoric/cosmic-swingset:latest
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: agoric/agoric-sdk
         dockerfile: packages/deployment/Dockerfile.sdk
@@ -47,7 +47,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Build ibc-alpha image
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: agoric/agoric-sdk
         dockerfile: packages/deployment/Dockerfile.ibc-alpha
@@ -62,7 +62,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Build ag-solo image
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: agoric/cosmic-swingset-solo
         dockerfile: packages/cosmic-swingset/lib/ag-solo/Dockerfile
@@ -78,7 +78,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Build setup image
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: agoric/cosmic-swingset-setup
         dockerfile: packages/deployment/Dockerfile
@@ -93,7 +93,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Build setup image
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: agoric/deployment
         dockerfile: packages/deployment/Dockerfile.deployment


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore